### PR TITLE
Allow running against main

### DIFF
--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -88,7 +88,6 @@ namespace :psdb do
         if branch.blank? || database.blank?
           raise "Your branch is not properly setup, please switch to a branch by using the CLI."
         end
-        raise "Unable to run migrations against the main branch" if branch == "main"
 
         config = Rails.configuration.database_configuration[Rails.env][name]
 


### PR DESCRIPTION
Better to allow it and let the script fail when safe migrations are enabled.