### PR TITLE
Specify service token permissions in GitHub Actions example

### DIFF
--- a/actions-example.md
+++ b/actions-example.md
@@ -18,7 +18,7 @@ Secrets needed to be set:
 - `PLANETSCALE_SERVICE_TOKEN_ID`
 - `PLANETSCALE_SERVICE_TOKEN`
 
-The PlanetScale service token must have permission on the database to create/read development branches, as well as create deploy requests.
+The PlanetScale service token must have the `connect_branch`, `create_branch`, `read_branch`, `create_deploy_request`, and `read_deploy_request` permissions on the database.
 
 ```yaml
 name: Run database migrations


### PR DESCRIPTION
The example for setting up a GitHub Actions workflow with a Rails app on PlanetScale is 💯! 🙏

One minor piece of friction I experienced was setting up a service token with the correct permissions. Took me a bit to realize that the "this user does not have the appropriate permissions" error meant that I had to add the `connect_branch` permission, or that the comment was failing to post because I had to add the `read_deploy_request` permission.

This PR specifies exactly which service token permissions this workflow requires.