### PR TITLE
Disable schema dump after running migrations + improve SSL cert

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,12 @@
 AllCops:
   TargetRubyVersion: 3
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -85,7 +85,15 @@ namespace :psdb do
         adapter = "trilogy"
       end
 
-      "#{adapter}://#{username}:#{password}@#{host}:3306/#{database}?ssl_mode=VERIFY_IDENTITY"
+      # Check common CA paths for certs.
+      ssl_ca_path = %w[/etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/ca-bundle.pem /etc/ssl/cert.pem].find { |f| File.exist?(f) }
+      url = "#{adapter}://#{username}:#{password}@#{host}:3306/#{database}?ssl_mode=VERIFY_IDENTITY"
+
+      if ssl_ca_path
+        url += "&ssl_ca=#{ssl_ca_path}"
+      end
+
+      url
     else
       puts "Failed to create credentials for PlanetScale #{db_branch_colorized(database, branch)}"
       puts "Command: #{command}"

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -118,7 +118,7 @@ namespace :psdb do
 
     puts "Running migrations..."
 
-    command = "DATABASE_URL=#{ENV["PSCALE_DATABASE_URL"]} bundle exec rails db:migrate"
+    command = "DATABASE_URL=\"#{ENV["PSCALE_DATABASE_URL"]}\" bundle exec rails db:migrate"
     IO.popen(command) do |io|
       io.each_line do |line|
         puts line
@@ -141,7 +141,7 @@ namespace :psdb do
         puts "Running migrations..."
 
         name_env_key = "#{name.upcase}_DATABASE_URL"
-        command = "#{name_env_key}=#{ENV["PSCALE_DATABASE_URL"]} bundle exec rails db:migrate:#{name}"
+        command = "#{name_env_key}=\"#{ENV["PSCALE_DATABASE_URL"]}\" bundle exec rails db:migrate:#{name}"
 
         IO.popen(command) do |io|
           io.each_line do |line|
@@ -168,7 +168,7 @@ namespace :psdb do
           puts "Loading schema..."
 
           name_env_key = "#{name.upcase}_DATABASE_URL"
-          command = "#{name_env_key}=#{ENV["PSCALE_DATABASE_URL"]} bundle exec rake db:schema:load:#{name}"
+          command = "#{name_env_key}=\"#{ENV["PSCALE_DATABASE_URL"]}\" bundle exec rake db:schema:load:#{name}"
 
           IO.popen(command) do |io|
             io.each_line do |line|
@@ -194,7 +194,7 @@ namespace :psdb do
       raise "Found multiple database configurations, please specify which database you want to rollback using `psdb:rollback:<database_name>`".colorize(:red)
     end
 
-    command = "DATABASE_URL=#{ENV["PSCALE_DATABASE_URL"]} bundle exec rails db:rollback"
+    command = "DATABASE_URL=\"#{ENV["PSCALE_DATABASE_URL"]}\" bundle exec rails db:rollback"
 
     IO.popen(command) do |io|
       io.each_line do |line|
@@ -223,7 +223,7 @@ namespace :psdb do
         puts "Rolling back migrations..."
 
         name_env_key = "#{name.upcase}_DATABASE_URL"
-        command = "#{name_env_key}=#{ENV["PSCALE_DATABASE_URL"]} bundle exec rake db:rollback:#{name}"
+        command = "#{name_env_key}=\"#{ENV["PSCALE_DATABASE_URL"]}\" bundle exec rake db:rollback:#{name}"
 
         IO.popen(command) do |io|
           io.each_line do |line|

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -85,12 +85,14 @@ namespace :psdb do
         adapter = "trilogy"
       end
 
+      # Setting schema_dump to nil is intentional. It prevents Rails from creating a dump after running migrations.
+      url = "#{adapter}://#{username}:#{password}@#{host}:3306/#{database}?ssl_mode=VERIFY_IDENTITY&schema_dump="
+
       # Check common CA paths for certs.
       ssl_ca_path = %w[/etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/ca-bundle.pem /etc/ssl/cert.pem].find { |f| File.exist?(f) }
-      url = "#{adapter}://#{username}:#{password}@#{host}:3306/#{database}?ssl_mode=VERIFY_IDENTITY"
 
       if ssl_ca_path
-        url += "&ssl_ca=#{ssl_ca_path}"
+        url += "&sslca=#{ssl_ca_path}"
       end
 
       url


### PR DESCRIPTION
Fixes: https://github.com/planetscale/planetscale_rails/issues/17

## Disabling schema dump
For the schema dump. I've found that when rails generates schema.rb or structure.sql, it runs an incredible amount of queries to construct the dump.

Normally, with local mysql this is fine because there is nearly no latency per query. When running this against a cloud database, it adds up very quickly.

One of our example databases takes a full minute to dump (my laptop is 30ms from the database).

By adding `schema_dump=`, this sets the Rails config for schema_dump to `nil`. Telling Rails not to run the dump.

`schema_dump=false` does not work because this sets it to a string, which rails interprets at the filename where we want the dump stored.

## SSL
To make this more reliable for more environments. We now check the most common SSL paths for a cert. If we find one, then we pass it.