### PR TITLE
better search for .pscale.yml file

### DIFF
--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -14,8 +14,9 @@ def find_git_directory
   current_path = Pathname.new(Dir.pwd)
 
   until current_path.root?
-    git_dir = current_path.join('.git')
+    git_dir = current_path.join(".git")
     return current_path.to_s if git_dir.exist? # this can be a directory or a file (worktree)
+
     current_path = current_path.parent
   end
 


### PR DESCRIPTION
In the case of monorepos, the .pscale.yml file may not be in the current working directory as the pscale CLI will write it in the Git root. This modifies the search logic to find the git root in the event that the .pscale.yml file is not found in the CWD.

We are checking the use cases that the GIT_DIR is set or the user is in a Git worktree as well.

This addresses #21 