### PR TITLE
Update connection to work for multi-keyspace databases

### DIFF
--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -112,7 +112,7 @@ namespace :psdb do
         adapter = "trilogy"
       end
 
-      url = "#{adapter}://#{username}:#{password}@#{host}:3306/#{database}?ssl_mode=VERIFY_IDENTITY"
+      url = "#{adapter}://#{username}:#{password}@#{host}:3306/@primary?ssl_mode=VERIFY_IDENTITY"
 
       # Check common CA paths for certs.
       ssl_ca_path = %w[/etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/ca-bundle.pem /etc/ssl/cert.pem].find { |f| File.exist?(f) }


### PR DESCRIPTION
By setting database to `@primary`, all DDL will be routed by vitess to the correct keyspace.

Previously, by setting `database`, we were targeting a single keyspace by default.

With the `@primary` change, any changes to existing tables will be routed correctly. When using `create_table`, the keyspace still needs to be specified. Will do a follow up PR to make creating tables easier.

I also explored leaving it `nil`. The problem with that is: Rails will fallback to whatever is set in `database.yml`. Which overrides the nil and sets a database name for us. Using `@primary` makes everything just work without any database.yml hacks.