### PR TITLE
Allow `create_table` to take a keyspace option for multi-keyspace databases

### DIFF
--- a/lib/planetscale_rails.rb
+++ b/lib/planetscale_rails.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "planetscale_rails/version"
+require_relative "planetscale_rails/migration"
 
 module PlanetscaleRails
   require "planetscale_rails/railtie" if defined?(Rails)
+end
+
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Migration::Current.prepend(PlanetscaleRails::Migration::Current)
 end

--- a/lib/planetscale_rails.rb
+++ b/lib/planetscale_rails.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support"
+
 require_relative "planetscale_rails/version"
 require_relative "planetscale_rails/migration"
 

--- a/lib/planetscale_rails/migration.rb
+++ b/lib/planetscale_rails/migration.rb
@@ -1,0 +1,18 @@
+module PlanetscaleRails
+  module Migration
+    module Current
+      # Allows users to set the `keyspace` option in their migration file.
+      # If the migration is being run against PlanetScale (i.e. `ENABLE_PSDB` is set), then we prepend the keyspace to the table name.
+      #
+      # For local MySQL databases, the keyspace is ignored.
+      def create_table(table_name, **options)
+        if ENV['ENABLE_PSDB'] && options[:keyspace].present?
+          table_name = "#{options[:keyspace]}.#{table_name}"
+          super(table_name, **options.except(:keyspace))
+        else
+          super(table_name, **options)
+        end
+      end
+    end
+  end
+end

--- a/lib/planetscale_rails/migration.rb
+++ b/lib/planetscale_rails/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PlanetscaleRails
   module Migration
     module Current
@@ -6,7 +8,7 @@ module PlanetscaleRails
       #
       # For local MySQL databases, the keyspace is ignored.
       def create_table(table_name, **options)
-        if ENV['ENABLE_PSDB'] && options[:keyspace].present?
+        if ENV["ENABLE_PSDB"] && options[:keyspace].present?
           table_name = "#{options[:keyspace]}.#{table_name}"
           super(table_name, **options.except(:keyspace))
         else

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -135,6 +135,7 @@ namespace :psdb do
   task "create_creds" => %i[environment check_ci] do
     ENV["PSCALE_DATABASE_URL"] = create_connection_string
     ENV["DISABLE_SCHEMA_DUMP"] = "true"
+    ENV["ENABLE_PSDB"] = "true"
   end
 
   desc "Connects to the current PlanetScale branch and runs rails db:migrate"


### PR DESCRIPTION
For databases with multiple keyspaces, all DDL is automatically routed to the correct keyspace with the exception of `CREATE TABLE`. For this, we need to tell vitess where we want the table to go.

This PR enables `create_table` to take a `keyspace` argument. Which is then prepended to the table name when running the migration.

This will only run when ENABLE_PSDB is set. This allows `create_table` to both work against PlanetScale/Vitess as well as local MySQL for development.

## Example

```ruby
class ChangeSomething < ActiveRecord::Migration[7.1]
  def change
    create_table(:new_table, id: { type: :bigint, unsigned: true }, keyspace: "planetscale-sharded") do |t|
      t.string :name
    end
    # will create a table `planetscale-sharded.new_table`
  end
end
```