### PR TITLE
Add `keyspace` to `drop_table`

### DIFF
--- a/lib/planetscale_rails/migration.rb
+++ b/lib/planetscale_rails/migration.rb
@@ -13,6 +13,13 @@ module PlanetscaleRails
         end
         super(table_name, **options.except(:keyspace))
       end
+
+      def drop_table(table_name, **options)
+        if ENV["ENABLE_PSDB"] && options[:keyspace].present?
+          table_name = "#{options[:keyspace]}.#{table_name}"
+        end
+        super(table_name, **options.except(:keyspace))
+      end
     end
   end
 end


### PR DESCRIPTION
Handles for the case where tables with the same name are in multiple keyspaces. This allows to target a specific keyspace to remove the table.