### PR TITLE
Improve ENV var error message + also support `PLANETSCALE_` env vars

### DIFF
--- a/actions-example.md
+++ b/actions-example.md
@@ -79,8 +79,8 @@ jobs:
         run: |
           bundle exec rails psdb:migrate > migration-output.txt
         env:
-          PSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
-          PSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
       - name: Open DR if migrations
         run: |
           if grep -q "migrated" migration-output.txt; then

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -72,11 +72,20 @@ end
 
 namespace :psdb do
   task check_ci: :environment do
-    use_service_token = ENV["PSCALE_SERVICE_TOKEN"] && ENV["PSCALE_SERVICE_TOKEN_ID"]
-    if ENV["CI"]
-      raise "For CI, you can only authenticate using service tokens." unless use_service_token
+    service_token = ENV["PSCALE_SERVICE_TOKEN"] || ENV["PLANETSCALE_SERVICE_TOKEN"]
+    service_token_id = ENV["PSCALE_SERVICE_TOKEN_ID"] || ENV["PLANETSCALE_SERVICE_TOKEN_ID"]
+    use_service_token = service_token && service_token_id
 
-      service_token_config = "--service-token #{ENV["PSCALE_SERVICE_TOKEN"]} --service-token-id #{ENV["PSCALE_SERVICE_TOKEN_ID"]}"
+    if ENV["CI"]
+      unless use_service_token
+        missing_vars = []
+        missing_vars << "PLANETSCALE_SERVICE_TOKEN" unless service_token
+        missing_vars << "PLANETSCALE_SERVICE_TOKEN_ID" unless service_token_id
+
+        raise "Unable to authenticate to PlanetScale. Missing environment variables: #{missing_vars.join(", ")}"
+      end
+
+      service_token_config = "--service-token #{service_token} --service-token-id #{service_token_id}"
 
       ENV["SERVICE_TOKEN_CONFIG"] = service_token_config
     end

--- a/lib/planetscale_rails/tasks/psdb.rake
+++ b/lib/planetscale_rails/tasks/psdb.rake
@@ -74,10 +74,10 @@ namespace :psdb do
   task check_ci: :environment do
     service_token = ENV["PSCALE_SERVICE_TOKEN"] || ENV["PLANETSCALE_SERVICE_TOKEN"]
     service_token_id = ENV["PSCALE_SERVICE_TOKEN_ID"] || ENV["PLANETSCALE_SERVICE_TOKEN_ID"]
-    use_service_token = service_token && service_token_id
+    service_token_available = service_token && service_token_id
 
     if ENV["CI"]
-      unless use_service_token
+      unless service_token_available
         missing_vars = []
         missing_vars << "PLANETSCALE_SERVICE_TOKEN" unless service_token
         missing_vars << "PLANETSCALE_SERVICE_TOKEN_ID" unless service_token_id


### PR DESCRIPTION
The `PLANETSCALE_` prefix is what the CLI uses. Updating to support both + improve the error message. Makes it less confusing for people using both this gem and `pscale` in the same actions workflows.